### PR TITLE
Unity 2017 or newer editor prefs support

### DIFF
--- a/Editor/PlayerPrefsEditor.cs
+++ b/Editor/PlayerPrefsEditor.cs
@@ -98,6 +98,15 @@ public class PlayerPrefsEditor : EditorWindow
         editor.minSize = minSize;
     }
 
+    private static string GetMacOSEditorPrefsPath()
+    {
+        // From Unity Docs: On macOS, EditorPrefs are stored in ~/Library/Preferences/com.unity3d.UnityEditor.plist.
+        string majorVersion = Application.unityVersion.Split('.')[0];
+        // Construct the fully qualified path
+        string editorPrefsPath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library/Preferences"), "com.unity3d.UnityEditor" + majorVersion + ".x.plist");
+        return editorPrefsPath;
+    }
+
     private void OnEnable()
     {
         searchField = new SearchField();
@@ -247,10 +256,7 @@ public class PlayerPrefsEditor : EditorWindow
 
             if (showEditorPrefs)
             {
-                // From Unity Docs: On macOS, EditorPrefs are stored in ~/Library/Preferences/com.unity3d.UnityEditor.plist.
-                string majorVersion = Application.unityVersion.Split('.')[0];
-                // Construct the fully qualified path
-                playerPrefsPath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library/Preferences"), "com.unity3d.UnityEditor" + majorVersion + ".x.plist");
+                playerPrefsPath = GetMacOSEditorPrefsPath();
             }
             else
             {
@@ -1051,10 +1057,7 @@ public class PlayerPrefsEditor : EditorWindow
 
             if (showEditorPrefs)
             {
-                // From Unity Docs: On macOS, EditorPrefs are stored in ~/Library/Preferences/com.unity3d.UnityEditor.plist.
-                string majorVersion = Application.unityVersion.Split('.')[0];
-                // Construct the fully qualified path
-                playerPrefsPath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library/Preferences"), "com.unity3d.UnityEditor" + majorVersion + ".x.plist");
+                playerPrefsPath = GetMacOSEditorPrefsPath();
             }
             else
             {

--- a/Editor/PlayerPrefsEditor.cs
+++ b/Editor/PlayerPrefsEditor.cs
@@ -100,10 +100,17 @@ public class PlayerPrefsEditor : EditorWindow
 
     private static string GetMacOSEditorPrefsPath()
     {
+#if UNITY_2017_4_OR_NEWER
+        // From Unity Docs: On macOS, EditorPrefs are stored in ~/Library/Preferences/com.unity3d.UnityEditor5.x.plist
+        // https://docs.unity3d.com/2017.4/Documentation/ScriptReference/EditorPrefs.html
+        string fileName = "com.unity3d.UnityEditor5.x.plist";
+#else
         // From Unity Docs: On macOS, EditorPrefs are stored in ~/Library/Preferences/com.unity3d.UnityEditor.plist.
-        string majorVersion = Application.unityVersion.Split('.')[0];
+        // https://docs.unity3d.com/2017.3/Documentation/ScriptReference/EditorPrefs.html
+        string fileName = "com.unity3d.UnityEditor.plist";
+#endif
         // Construct the fully qualified path
-        string editorPrefsPath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library/Preferences"), "com.unity3d.UnityEditor" + majorVersion + ".x.plist");
+        string editorPrefsPath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library/Preferences"), fileName);
         return editorPrefsPath;
     }
 

--- a/Editor/PlayerPrefsEditor.cs
+++ b/Editor/PlayerPrefsEditor.cs
@@ -303,9 +303,17 @@ public class PlayerPrefsEditor : EditorWindow
 
             if (showEditorPrefs)
             {
-                string majorVersion = Application.unityVersion.Split('.')[0];
+                // Starting Unity 5.5 registry key has " 5.x" suffix: https://docs.unity3d.com/550/Documentation/ScriptReference/EditorPrefs.html
+                // Even though for some versions of Unity docs state that N.x suffix is used where N.x is the major version number,
+                // it's still " 5.x" suffix used for that cases which is probably bug in the docs.
+                // Note that starting 2019.2 docs have " 5.x" suffix: https://docs.unity3d.com/2019.2/Documentation/ScriptReference/EditorPrefs.html
+#if UNITY_5_5_OR_NEWER
+                string subKeyPath = "Software\\Unity Technologies\\Unity Editor 5.x";
+#else
+                string subKeyPath = "Software\\Unity Technologies\\Unity Editor";
+#endif
 
-                registryKey = Microsoft.Win32.Registry.CurrentUser.OpenSubKey("Software\\Unity Technologies\\Unity Editor " + majorVersion + ".x");
+                registryKey = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(subKeyPath);
             }
             else
             {


### PR DESCRIPTION
### Summary
Fix editor window failing to load EditorPrefs due to incorrect file paths.

### Details
This was found by trying to inspect editor prefs via editor window using Unity 2019.3.0f6 on Windows. Starting with Unity 2017, versioning of the engine changed resulting in major version value returned being incompatible with expected path (so for example for Unity 2019.3.0f6 major version returned by code would be 2019 resulting in Windows registry key `Software\\Unity Technologies\\Unity Editor 2019.x` which is not found).

Updated code for both Windows and macOS EditorPrefs path retrival based on Unity documentation https://docs.unity3d.com/2019.3/Documentation/ScriptReference/EditorPrefs.html. Used dropdown on top left to identify Unity version which introduced changes in the EditorPrefs paths and ensure paths used are compatible with all Unity versions listed in dropdown.

Tested on:
* Windows, Unity 2019.3.0f6
* Windows, Unity 2018.4.6f1
* Windows, Unity 2017.4.32f1 
* macOS, Unity 2018.4.6f1

### How to test
Run editor window using Unity editor on Windows and macOS for various Unity versions and observe EditorPrefs being loaded (can check via setting breakpoint). Once loaded, can use editor widow to add test key to EditorPrefs to see it's actually stored there. Noticed that for macOS .plist file with EditorPrefs is written to disk after Unity is closed, no the moment `EditorPrefs.Set*` method is called.

### Possible next steps
Currently editor window does not display any error if failed to find EditorPrefs at the expected path resulting in same view of the window for both empty EditorPrefs and EditorPrefs failed to load due to path. Distinguishing these cases visually can help understanding whether EditorPrefs were loaded w/o need to debug.