### PR TITLE
Fix enter playmode exception caused by search

### DIFF
--- a/Editor/PlayerPrefsEditor.cs
+++ b/Editor/PlayerPrefsEditor.cs
@@ -1054,12 +1054,8 @@ namespace Sabresaurus.PlayerPrefsEditor
             EditorGUILayout.EndHorizontal();
         }
 
-        private void OnGUI()
+        private void DeserializePrefsIntoCache()
         {
-            EditorGUILayout.Space();
-
-            DrawTopBar();
-
             if (Application.platform == RuntimePlatform.OSXEditor)
             {
                 string playerPrefsPath;
@@ -1113,6 +1109,15 @@ namespace Sabresaurus.PlayerPrefsEditor
                     lastDeserialization = DateTime.UtcNow;
                 }
             }
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.Space();
+
+            DrawTopBar();
+
+            DeserializePrefsIntoCache();
 
             DrawMainList();
 

--- a/Editor/PlayerPrefsEditor.cs
+++ b/Editor/PlayerPrefsEditor.cs
@@ -119,7 +119,7 @@ namespace Sabresaurus.PlayerPrefsEditor
         {
             searchField = new SearchField();
 
-            DeserializePrefsIntoCache();
+            deserializedPlayerPrefs = new List<PlayerPrefPair>(RetrieveSavedPrefs(PlayerSettings.companyName, PlayerSettings.productName));
             UpdateSearch();
         }
 

--- a/Editor/PlayerPrefsEditor.cs
+++ b/Editor/PlayerPrefsEditor.cs
@@ -15,7 +15,6 @@ namespace Sabresaurus.PlayerPrefsEditor
         private static System.Text.Encoding encoding = new System.Text.UTF8Encoding();
 
         // Represents a PlayerPref key-value record
-        [Serializable]
         private struct PlayerPrefPair
         {
             public string Key

--- a/Editor/PlayerPrefsEditor.cs
+++ b/Editor/PlayerPrefsEditor.cs
@@ -119,6 +119,9 @@ namespace Sabresaurus.PlayerPrefsEditor
         private void OnEnable()
         {
             searchField = new SearchField();
+
+            DeserializePrefsIntoCache();
+            UpdateSearch();
         }
 
         private void DeleteAll()


### PR DESCRIPTION
### Summary
Fix null reference exception thrown when entering play mode with non-zero search hits.

### Details
Explanation of the root cause can be found in https://github.com/sabresaurus/PlayerPrefsEditor/issues/5#issuecomment-777046984 and in the commit e60aaf0bfe1a5b0ba0acfbbe21be3dec6eb2fcd9 message. Unity does serialization of `PlayerPrefsEditor` since it inherits `EditorWindow`.

### How to test
Checkout target branch. Open editor, search "unity", make sure search results are not empty. Enter playmode and observe exception in the console.

Checkout source branch. Repeat steps and observe no exception. Check that search results are persistent when stopping play mode. Check editor behaves as before when opening and closing.

Tested with 2019.4.8f1 on Windows.

Would be great if @tracer8 could test source branch as well.

Closes #5